### PR TITLE
Typo in field name in instruction schema.

### DIFF
--- a/specification/schema.json
+++ b/specification/schema.json
@@ -233,7 +233,7 @@
                         "text":{
                            "type":"string"
                         },
-                        "imagUurls":{
+                        "images":{
                            "type":"array",
                            "items":{
                               "type":"string"


### PR DESCRIPTION
The field seems to be called `images` in the examples (ie, https://github.com/garyhodgson/thing-tracker-site-template/blob/gh-pages/tracker.json ).